### PR TITLE
Join prefix with path directly

### DIFF
--- a/git/repo.go
+++ b/git/repo.go
@@ -217,11 +217,7 @@ func (r *Repo) Patch(id digest.Digest, dstPrefix string) (Patch, error) {
 		return Patch{}, err
 	}
 	fixPath := func(path string) string {
-		path = strings.TrimPrefix(path, r.prefix)
-		if dstPrefix != "" {
-			path = filepath.Join(dstPrefix, path)
-		}
-		return path
+		return dstPrefix + strings.TrimPrefix(path, r.prefix)
 	}
 
 	var diffs []Diff

--- a/main_test.go
+++ b/main_test.go
@@ -109,7 +109,7 @@ func TestGritRules(t *testing.T) {
 	remote.Git(t, "add", ".")
 	remote.Git(t, "commit", "-a", "-m", "commit 1 to remote")
 	remote.Git(t, "push")
-	g.Run(t, "-push", repoRemote, repoHome+",remote")
+	g.Run(t, "-push", repoRemote, repoHome+",remote/")
 
 	home.Git(t, "pull")
 
@@ -129,7 +129,7 @@ func TestGritRules(t *testing.T) {
 	remote.Git(t, "commit", "-a", "-m", "commit 1 2 remote")
 	remote.Git(t, "push")
 
-	g.Run(t, "-push", repoRemote, repoHome+",remote", "strip:^/BUILD$", "strip:^BUILD/")
+	g.Run(t, "-push", repoRemote, repoHome+",remote/", "strip:^BUILD$")
 
 	home.Git(t, "pull")
 


### PR DESCRIPTION
Assume less about Git paths by joining prefix directly.  This was a bit wonky before, so we also have to adjust tests.